### PR TITLE
Docker and README minor improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ COPY . /opt/rcj-cms/
 WORKDIR /opt/rcj-cms
 
 # install deps + build assets
-RUN npm ci \
- && npm install -g bower \
- && bower install --allow-root \
- && npm run build \
- && mkdir -p logs documents
+RUN npm install -g workbox-cli
+RUN npm install -g bower
+RUN bower install --allow-root
+RUN npm run build
+RUN mkdir -p logs documents
 
 CMD ["npm", "run", "start"]
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ For detail, please check [helper files](https://github.com/robocup-junior/rcj-cm
 #### Using Docker Compose (self-host)
 This repository can also be run using Docker Compose (app + MongoDB + Redis). This is suitable for local testing and self-hosting.
 
-1) Create/update `process.env` (SMTP / mail settings, hostnames, etc.)
+1) Create/update `process.env` (SMTP / mail settings, hostnames, etc.) if needed.
 2) Start the stack:
    `docker compose up -d --build`
+3) Now you can open the app under `localhost:3000`
+4) Everytime you modify something, you'll need to rebuild the docker container as in step #2.
 
 **Note about configuration changes (`process.env`):**  
 When using `env_file:` in `docker-compose.yml`, environment variables are read when the container is created.  


### PR DESCRIPTION
## Description
This was tested on Windows + Docker

Docker changes:
1. `workbox-cli` needs to be installed
2. Running in separate commands makes it easier to debug if something goes wrong
3. `npm ci` was failing to run, but I also don't think it's needed.

Readme:
Clarified some instructions in how to use docker compose.

## Type of Change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Ran `docker compose up -d --build` and verified that the webpage was up and running locally

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules