### PR TITLE
Fix editor bug in 2025 Maze Entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rcj-scoring",
-  "version": "25.2.6",
+  "version": "25.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rcj-scoring",
-      "version": "25.2.6",
+      "version": "25.2.7",
       "license": "MIT",
       "dependencies": {
         "@bull-board/express": "5.20.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rcj-scoring",
-  "version": "25.2.6",
-  "copyright": "2016-2025 RoboCupJunior Rescue CMS Development SubCommittee",
+  "version": "25.2.7",
+  "copyright": "2016-2026 RoboCupJunior Rescue CMS Development SubCommittee",
   "private": true,
   "scripts": {
     "start": "node server.js",

--- a/public/javascripts/admin/mapEditor/maze_2025E.js
+++ b/public/javascripts/admin/mapEditor/maze_2025E.js
@@ -916,7 +916,7 @@ app.controller('MazeEditorController', ['$scope', '$uibModal', '$log', '$http','
     $scope.open = function (x, y, z) {
         var modalInstance = $uibModal.open({
             animation: true,
-            templateUrl: '/templates/maze_editor_modal_2025.html',
+            templateUrl: '/templates/maze_editor_modal_2025E.html',
             controller: 'ModalInstanceCtrl',
             size: 'sm',
             scope: $scope,


### PR DESCRIPTION
## Description
Fix a bug that blocks users from creating the maze 2025 entry map.
The user can not set entry rules' victims for entry maps.

Fixes # (issue number)

## Type of Change
Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules