### PR TITLE
Add scoring logic for blue tiles in Maze 2026

### DIFF
--- a/helper/scoreCalculatorRules/2026.js
+++ b/helper/scoreCalculatorRules/2026.js
@@ -147,6 +147,15 @@ module.exports.calculateMazeScore = function (run) {
     };
 
 
+    // Checking blue tiles visits
+    if (mapTiles[coord].tile.blue) {
+      const blueVisits = tile.scoredItems.blue || 0;
+
+      if (blueVisits > 0) {
+        score +=  Math.max(0, MAX_BLUE_BONUS - blueVisits * BLUE_VISIT_PENALTY);
+      }
+    }
+
 
 
     // helper: count valid kits for a single victim (ONLY called when victim is scored)

--- a/helper/scoreCalculatorRules/2026.js
+++ b/helper/scoreCalculatorRules/2026.js
@@ -100,6 +100,8 @@ module.exports.calculateLineScore = function (run) {
  * @returns {number}
  */
 module.exports.calculateMazeScore = function (run) {
+  const MAX_BLUE_BONUS = 40;
+  const BLUE_VISIT_PENALTY = 10;
   const MAX_RESCUE_KITS = 8;
 
   let score = 0;
@@ -144,6 +146,9 @@ module.exports.calculateMazeScore = function (run) {
       Green: 0,
     };
 
+
+
+
     // helper: count valid kits for a single victim (ONLY called when victim is scored)
     function addRescueKitsFor(side, victimType, droppedKits) {
       if (rescueKits >= MAX_RESCUE_KITS) return;
@@ -160,7 +165,7 @@ module.exports.calculateMazeScore = function (run) {
       rescueKits += valid;
     }
 
-    if (mapTiles[coord].tile.victims.top != 'None') {
+
     if (mapTiles[coord].tile.victims.top !== 'None') {
       if (tile.scoredItems.victims.top) {
         addVictimCount(victims, mapTiles[coord].tile.victims.top);
@@ -261,5 +266,4 @@ function convert(obj) {
       'count': o[1]
     }
   })
-}
 }

--- a/models/mazeMap.js
+++ b/models/mazeMap.js
@@ -167,7 +167,7 @@ mazeMapSchema.pre('save', function (next) {
         }
       }
 
-      if (cell.tile.black || cell.tile.checkpoint || cell.tile.steps || cell.tile.speedbump || cell.tile.ramp || cell.tile.blueTile || cell.tile.redTile) {
+      if (cell.tile.black || cell.tile.checkpoint || cell.tile.steps || cell.tile.speedbump || cell.tile.ramp || cell.tile.blue || cell.tile.redTile) {
         if ((cell.tile.victims.top != null &&
              cell.tile.victims.top != "None") ||
         
@@ -188,10 +188,10 @@ mazeMapSchema.pre('save', function (next) {
       }
 
       if (self.leagueType == "entry") { // Validation for Rescue Maze Entry League
-        if (cell.tile.steps || cell.tile.ramp || cell.tile.blueTile) {
+        if (cell.tile.steps || cell.tile.ramp || cell.tile.blue) {
           cell.tile.steps = false;
           cell.tile.ramp = false;
-          cell.tile.blueTile = false;
+          cell.tile.blue = false;
         }
       }
       

--- a/models/mazeRun.js
+++ b/models/mazeRun.js
@@ -45,6 +45,7 @@ const mazeRunSchema = new Schema({
       checkpoint: {type: Boolean, default: false},
       ramp  : {type: Boolean, default: false},
       steps     : {type: Boolean, default: false},
+      blue      : {type: Number, integer: true, min: 0, default: 0},
       victims   : {
         top   : {type: Boolean, default: false},
         right : {type: Boolean, default: false},

--- a/public/javascripts/judge/maze_2026.js
+++ b/public/javascripts/judge/maze_2026.js
@@ -480,6 +480,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                     checkpoint: false,
                     ramp: false,
                     steps:  false,
+                    blue: 0,
                     victims: {
                         top: false,
                         right: false,
@@ -553,6 +554,13 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
             if (tile.scoredItems.victims.bottom) current += Math.min(tile.scoredItems.rescueKits.bottom, (maxKit[cell.tile.victims.bottom] || 0));
         }
 
+        if (cell.tile.blue) {
+            possible++;
+            if (tile.scoredItems.blue > 0) {
+                current++;
+            }
+        }
+
         if (tile.processing)
             return "processing";
         else if (current > 0 && current == possible)
@@ -580,6 +588,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                     speedbump: false,
                     checkpoint: false,
                     ramp: false,
+                    blue: 0,
                     victims: {
                         top: false,
                         right: false,
@@ -668,6 +677,12 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
             }
         }
 
+        const MAX_BLUE_BONUS = 40;
+        const BLUE_VISIT_PENALTY = 10;
+        if (cell.tile.blue && tile.scoredItems.blue > 0) {
+            current += Math.max(0, MAX_BLUE_BONUS - tile.scoredItems.blue * BLUE_VISIT_PENALTY);
+        }
+
         return current;
     };
 
@@ -687,6 +702,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                     checkpoint: false,
                     ramp: false,
                     steps: false,
+                    blue: 0,
                     victims: {
                         top: false,
                         right: false,
@@ -710,11 +726,11 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
             (cell.tile.victims.left != "None");
 
         // Total number of scorable things on this tile
-        var total = !!cell.tile.speedbump + !!cell.tile.checkpoint + !!cell.tile.steps + !!cell.tile.ramp + hasVictims;
+        var total = !!cell.tile.speedbump + !!cell.tile.checkpoint + !!cell.tile.steps + !!cell.tile.ramp + !!cell.tile.blue + hasVictims;
         console.log("totalt antal saker", total);
         console.log("Has victims", hasVictims);
 
-        if (total == 1 && !hasVictims) {
+        if (total == 1 && !hasVictims && !cell.tile.blue) {
             if (cell.tile.speedbump) {
                 tile.scoredItems.speedbump = !tile.scoredItems.speedbump;
             }
@@ -733,8 +749,8 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                 }
             };
             upload_run(httpdata);
-        } else if (total > 1 || hasVictims) {
-            // Open modal for multi-select
+        } else if (total > 1 || hasVictims || cell.tile.blue) {
+            // Open modal for multi-select or blue tile
             $scope.open(x, y, z);
         }
 
@@ -962,6 +978,19 @@ app.controller('ModalInstanceCtrl', ['$scope','$uibModalInstance','cell','tile',
     $scope.changeSteps = function(){
         playSound(sClick);
         $scope.tile.scoredItems.steps = !$scope.tile.scoredItems.steps;
+    };
+
+    $scope.incrementBlue = function(){
+        playSound(sClick);
+        $scope.tile.scoredItems.blue++;
+    };
+
+    $scope.decrementBlue = function(){
+        playSound(sClick);
+        $scope.tile.scoredItems.blue--;
+        if ($scope.tile.scoredItems.blue < 0) {
+            $scope.tile.scoredItems.blue = 0;
+        }
     };
 
     $scope.lightStatus = function(light, kit){

--- a/public/javascripts/manual/maze_2026.js
+++ b/public/javascripts/manual/maze_2026.js
@@ -71,6 +71,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
         "ramp":[],
         "speedbump":[],
         "steps":[],
+        "blue":[],
     };
 
     var db_cells;
@@ -246,6 +247,17 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                             }
                             $scope.itemList.steps.push(tmp);
                         }
+
+                        if(tile.blue){
+                            let tmp = {
+                                x: i,
+                                y: j,
+                                z: k,
+                                name: $scope.itemList.blue.length+1,
+                                type: "blue"
+                            }
+                            $scope.itemList.blue.push(tmp);
+                        }
                     }
                 }
             }
@@ -277,6 +289,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                     checkpoint: false,
                     ramp: false,
                     steps:  false,
+                    blue: 0,
                     victims: {
                         top: false,
                         right: false,
@@ -295,6 +308,8 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
         }
         if(item.direction){//Victims
             return $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.victims[item.direction];
+        }else if(item.type == 'blue'){
+            return true;
         }else{
             return $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems[item.type];
         }
@@ -308,6 +323,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                     checkpoint: false,
                     ramp: false,
                     steps:  false,
+                    blue: 0,
                     victims: {
                         top: false,
                         right: false,
@@ -332,6 +348,8 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
         playSound(sClick);
         if(item.direction) {//Victims
             $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.victims[item.direction] = !$scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.victims[item.direction];
+        }else if(item.type == 'blue'){
+            // No action for blue here, handled by input field directly in pug
         }else{
             $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems[item.type] = !$scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems[item.type];
         }

--- a/public/javascripts/sign/maze_2026.js
+++ b/public/javascripts/sign/maze_2026.js
@@ -273,6 +273,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                     checkpoint: false,
                     ramp: false,
                     steps: false,
+                    blue: 0,
                     victims: {
                         top: false,
                         right: false,
@@ -346,6 +347,13 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
             if (tile.scoredItems.victims.bottom) current += Math.min(tile.scoredItems.rescueKits.bottom, victimConstant[cell.tile.victims.bottom].maxKitNum);
         }
 
+        if (cell.tile.blue) {
+            possible++;
+            if (tile.scoredItems.blue > 0) {
+                current++;
+            }
+        }
+
         if (tile.processing)
             return "processing";
         else if (current > 0 && current == possible)
@@ -398,6 +406,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                     speedbump: false,
                     checkpoint: false,
                     ramp: false,
+                    blue: 0,
                     victims: {
                         top: false,
                         right: false,
@@ -485,7 +494,12 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
                 );
             }
         }
+        const MAX_BLUE_BONUS = 40;
+        const BLUE_VISIT_PENALTY = 10;
 
+        if (cell.tile.blue && tile.scoredItems.blue > 0) {
+            current += Math.max(0, MAX_BLUE_BONUS - tile.scoredItems.blue * BLUE_VISIT_PENALTY);
+        }
         return current;
     };
 

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -514,6 +514,8 @@
             "m_bump": "@:maze.view.m_bump",
             "m_ramp": "@:maze.view.m_ramp",
             "m_steps": "@:maze.view.m_steps",
+            "m_blue_tile": "Blue Tile",
+            "m_blue_visits": "Number of visits to this blue tile:",
             "m_flash": "@:maze.view.m_flash",
             "m_identified": "@:maze.view.m_identified",
             "m_kit": "@:maze.view.m_kit",

--- a/public/lang/ja.json
+++ b/public/lang/ja.json
@@ -512,6 +512,8 @@
             "m_bump": "@:maze.view.m_bump",
             "m_ramp": "@:maze.view.m_ramp",
             "m_steps": "@:maze.view.m_steps",
+            "m_blue_tile": "青いタイル",
+            "m_blue_visits": "この青いタイルへの訪問回数：",
             "m_flash": "@:maze.view.m_flash",
             "m_identified": "@:maze.view.m_identified",
             "m_kit": "@:maze.view.m_kit",

--- a/public/templates/maze_judge_modal.html
+++ b/public/templates/maze_judge_modal.html
@@ -41,6 +41,29 @@
             </div>
         </div>
         <hr ng-if="cell.tile.checkpoint || cell.tile.speedbump || cell.tile.steps || cell.tile.ramp">
+        <div class="row" ng-show="cell.tile.blue" style="margin-bottom: 20px;">
+            <div class="col-12">
+                <strong>{{"maze.judge.m_blue_tile" | translate}}</strong>
+                <br>
+                <p>{{"maze.judge.m_blue_visits" | translate}}</p>
+                <div class="input-group mb-3" style="width:100%;height:40px;">
+                    <div class="input-group-prepend">
+                        <button class="btn btn-danger" type="button" ng-click="decrementBlue()">
+                            <i class="fas fa-minus" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                    <div style="background-color: #F2F2F2; width:calc(100% - 80px); text-align: center;">
+                        <span class="count">{{tile.scoredItems.blue}}</span>
+                    </div>
+                    <div class="input-group-append">
+                        <button class="btn btn-success" type="button" ng-click="incrementBlue()">
+                            <i class="fas fa-plus" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <hr ng-if="cell.tile.blue">
         <div ng-show="hasVictims" ng-if="leagueType=='standard'">
             <i class="far fa-2x fa-lightbulb" aria-hidden="true" style="color:#f8b500;">&nbsp;</i>{{"maze.judge.m_flash" | translate}}
             <div ng-repeat="(direction, type) in cell.tile.victims track by $index" ng-show="type != 'None'" style="margin-left:50px;" >

--- a/public/templates/maze_view_modal_2026.html
+++ b/public/templates/maze_view_modal_2026.html
@@ -3,7 +3,7 @@
 </div>
 <div class="modal-body">
     <ul style="padding-inline-start: 0px;">
-        <div class="row" ng-show="cell.tile.checkpoint || cell.tile.speedbump || cell.tile.steps || cell.tile.ramp" style="margin-bottom: 20px;">
+        <div class="row" ng-show="cell.tile.checkpoint || cell.tile.speedbump || cell.tile.steps || cell.tile.ramp || cell.tile.blue" style="margin-bottom: 20px;">
             <div class="col-4" style="position: relative;text-align: center;" ng-show="cell.tile.checkpoint">
                 <span>{{"maze.judge.m_reach" | translate}}</span>
                 <img class="img-thumbnail" src="/images/checkpoint.png" width="100%" ng-style="{'background-color': tile.scoredItems.checkpoint?'#2ecc71':'#D91E18'}">
@@ -39,8 +39,17 @@
                     <i class="fas fa-times fa-fw fa-5x" ng-show="!tile.scoredItems.ramp" style="padding-top:4px; color:#ffffff; opacity:0.9;"></i>
                 </div>
             </div>
+
+            <div class="col-4" style="position: relative;text-align: center;" ng-show="cell.tile.blue">
+                <span>{{"maze.judge.blue" | translate}}</span>
+                <img class="img-thumbnail" src="/images/blue_tile.png" width="100%" ng-style="{'background-color': tile.scoredItems.blue>0?'#2ecc71':'#D91E18'}">
+                <div style="position: absolute; top:20px; left:10px;">
+                    <i class="fas fa-check fa-fw fa-5x" ng-show="tile.scoredItems.blue > 0" style="color:#ffffff; opacity:0.9;"></i>
+                    <i class="fas fa-times fa-fw fa-5x" ng-show="tile.scoredItems.blue == 0" style="padding-top:4px; color:#ffffff; opacity:0.9;"></i>
+                </div>
+            </div>
         </div>
-        <hr ng-if="cell.tile.checkpoint || cell.tile.speedbump || cell.tile.steps || cell.tile.ramp">
+        <hr ng-if="cell.tile.checkpoint || cell.tile.speedbump || cell.tile.steps || cell.tile.ramp || cell.tile.blue">
 
         <div ng-show="hasVictims">
             <i class="far fa-2x fa-lightbulb" aria-hidden="true" style="color:#f8b500;">&nbsp;</i>{{"maze.view.m_flash" | translate}}
@@ -94,7 +103,7 @@
                     <img src="/images/Green.png" height=45px ng-if="type=='Green'">
                     </label>
                 </div>
-        <div>
+        </div>
     </ul>
 </div>
 

--- a/views/manual/input/maze_2026.pug
+++ b/views/manual/input/maze_2026.pug
@@ -126,6 +126,15 @@ html(ng-app="ddApp")
                         td
                           button.btn(type='button',ng-click="toggleScored(item)",ng-class="{'btn-success': clearStatus(item),'btn-danger':!clearStatus(item)}",ng-if="!item.afterLoP",style="width:100%;height:100%;")
                             i.far(ng-class="{'fa-check-square': clearStatus(item), 'fa-times-circle': !clearStatus(item)}")
+                  .col-md-2(ng-repeat="item in itemList.blue")
+                    table(style="background-color:#DFF7FD;border:1px solid #444;width:100%;")
+                      tr(style="text-align:center;height:50px;")
+                        td(style="width:43px;")
+                          div(style="width:40px;height:40px;background-color:blue;margin-left:auto;margin-right:auto;border:1px solid #444;")
+                        td(style="width:35px;text-align:center;")
+                          span(style="font-size:30px") {{item.name}}
+                        td
+                          input.form-control(type='number', ng-model="tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blue", min='0', style="width:100%;height:100%;font-size:25px;text-align:center;")
 
 
         hr


### PR DESCRIPTION
## Description
This pull request adds scoring logic and UI support for blue tiles in Maze 2026. A bonus reward for blue tile visits and penalties for repeated visitation were introduced through configurable constants.

Fixes #89 

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules