### PR TITLE
Add scoring logic for reliability bonus

### DIFF
--- a/helper/scoreCalculatorRules/2026.js
+++ b/helper/scoreCalculatorRules/2026.js
@@ -116,6 +116,7 @@ module.exports.calculateMazeScore = function (run) {
 
   let victims = {};
   let rescueKits = 0;
+  let blueTilesVisited = 0;
 
   // New: track kits per victim (tile coord + side) so we can do 10 for 1 kit, 30 for 2 kits on SAME victim
   let kitsByVictim = {};
@@ -153,6 +154,7 @@ module.exports.calculateMazeScore = function (run) {
 
       if (blueVisits > 0) {
         score +=  Math.max(0, MAX_BLUE_BONUS - blueVisits * BLUE_VISIT_PENALTY);
+        blueTilesVisited++;
       }
     }
 
@@ -231,7 +233,10 @@ module.exports.calculateMazeScore = function (run) {
   }
   score += kitScore;
 
-  score += Math.max((totalVictimCount + Math.min(rescueKits, MAX_RESCUE_KITS) - run.LoPs) * 10, 0);
+  // Reliability bonus: (SVI) × 10 + (SRD) × 10 + (SBV) × 10 - (LoP) × 15
+  const reliabilityBonus = totalVictimCount * 10 + Math.min(rescueKits, MAX_RESCUE_KITS) * 10 + blueTilesVisited * 10 - run.LoPs * 15;
+  score += Math.max(reliabilityBonus, 0);
+
 
   if (run.exitBonus) {
     score += totalVictimCount * 10;

--- a/public/javascripts/sign/maze_2026.js
+++ b/public/javascripts/sign/maze_2026.js
@@ -199,19 +199,35 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
             });
     }
 
+    $scope.blueTilesVisited = function () {
+        let count = 0;
+        for (const key in $scope.tiles) {
+            if ($scope.tiles[key].scoredItems.blue > 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    $scope.rescueDeploymentPoints = function () {
+        return Math.min($scope.distKits, 8) * 10;
+    }
+
     $scope.reliability = function () {
+        const bonus = $scope.foundVictims * 10 + Math.min($scope.distKits, 8) * 10 + $scope.blueTilesVisited() * 10;
         if ($scope.leagueType == "entry") {
-            return Math.max(($scope.foundVictims * 10) - ($scope.LoPs * 5), 0);
+            return Math.max(bonus - ($scope.LoPs * 5), 0);
         } else {
-            return Math.max(($scope.foundVictims + $scope.distKits - $scope.LoPs) * 10, 0);
+            return Math.max(bonus - ($scope.LoPs * 15), 0);
         }
     }
 
     $scope.reliabilityLoPs = function () {
+        const bonus = $scope.foundVictims * 10 + Math.min($scope.distKits, 8) * 10 + $scope.blueTilesVisited() * 10;
         if ($scope.leagueType == "entry") {
-            return Math.min($scope.foundVictims * 10, $scope.LoPs * 5);
+            return Math.min(bonus, $scope.LoPs * 5);
         } else {
-            return Math.min(($scope.foundVictims + $scope.distKits) * 10, $scope.LoPs * 10);
+            return Math.min(bonus, $scope.LoPs * 15);
         }
     }
 

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -557,7 +557,8 @@
             "misidentification": "@:maze.view.misidentification",
             "write": "@:line.sign.write",
             "clear": "@:line.sign.clear",
-            "comp": "@:line.sign.comp"
+            "comp": "@:line.sign.comp",
+            "blue": "Successful blue tile visits"
         }
     },
     "admin": {

--- a/public/lang/ja.json
+++ b/public/lang/ja.json
@@ -555,7 +555,8 @@
             "misidentification": "@:maze.view.misidentification",
             "write": "@:line.sign.write",
             "clear": "@:line.sign.clear",
-            "comp": "@:line.sign.comp"
+            "comp": "@:line.sign.comp",
+            "blue": "訪問した青いタイル"
         }
     },
     "admin": {

--- a/views/view/common/maze_2026.pug
+++ b/views/view/common/maze_2026.pug
@@ -239,7 +239,16 @@ h2 {{'maze.sign.reliability' | translate}}
         | : {{distKits}}
         br
         br
-        |                     {{distKits * 10}} {{'common.point' | translate}}
+        |                     {{rescueDeploymentPoints()}} {{'common.point' | translate}}
+    .col-md-1
+      h1(style='line-height:140px;text-align:center;') +
+    .col-md-2
+      p(style='text-align:center;height:40px;') {{'maze.sign.blue' | translate}}
+      i.fas.fa-trailer.fa-2x(aria-hidden='true')
+        | : {{blueTilesVisited()}}
+        br
+        br
+        |                     {{blueTilesVisited() * 10}} {{'common.point' | translate}}
     .col-md-1
       h1(style='line-height:140px;text-align:center;') -
     .col-md-2
@@ -251,7 +260,7 @@ h2 {{'maze.sign.reliability' | translate}}
         |                     {{reliabilityLoPs()}} {{'common.point' | translate}}
     .col-md-1
       h1(style='line-height:140px;text-align:center;') =
-    .col-md-3
+    .col-md-2
       h1(style='line-height:140px;text-align:center;') {{reliability()}} {{'common.point' | translate}}
 .alert.alert-info(style='margin-bottom:30px;text-align:center;', role='alert', ng-if="leagueType=='entry'")
   .row
@@ -278,7 +287,7 @@ h2 {{'maze.sign.reliability' | translate}}
 h2 {{'maze.sign.calc' | translate}}
 .alert.alert-warning(style='margin-bottom:80px;text-align:center;', role='alert')
   .row
-    .col-md-2
+    .col-md-3
       p(style='height:30px;') {{'maze.sign.item' | translate}}
       h1
         | {{allItemScore()}} {{'common.point' | translate}}
@@ -297,6 +306,6 @@ h2 {{'maze.sign.calc' | translate}}
     .col-md-1
       p(style='height:30px;')
       h1 -
-    .col-md-3
+    .col-md-2
       p(style='height:30px;') {{'maze.sign.misidentification' | translate}}
       h1 {{MisIdent*5}} {{'common.point' | translate}}


### PR DESCRIPTION
## Description
This pull request adds scoring logic for blue tiles and reliability bonuses within the Maze 2026 game. It introduces translations and templates for blue tile scoring, as well as updates to the backend to track the number of blue tiles visited and compute the reliability bonus.

Fixes #91

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules