### PR TITLE
Add UI and logic for Maze 2026 scoring and navigation features

### DIFF
--- a/helper/scoreCalculatorRules/2026.js
+++ b/helper/scoreCalculatorRules/2026.js
@@ -117,6 +117,8 @@ module.exports.calculateMazeScore = function (run) {
   let victims = {};
   let rescueKits = 0;
   let blueTilesVisited = 0;
+  let stairsNavigation = 0;
+  let rampNavigation = 0;
 
   // New: track kits per victim (tile coord + side) so we can do 10 for 1 kit, 30 for 2 kits on SAME victim
   let kitsByVictim = {};
@@ -132,9 +134,11 @@ module.exports.calculateMazeScore = function (run) {
       score += 10;
     }
     if (tile.scoredItems.ramp && mapTiles[coord].tile.ramp) {
+      rampNavigation++;
       score += 10;
     }
     if (tile.scoredItems.steps && mapTiles[coord].tile.steps) {
+      stairsNavigation++;
       score += 10;
     }
 
@@ -237,9 +241,10 @@ module.exports.calculateMazeScore = function (run) {
   const reliabilityBonus = totalVictimCount * 10 + Math.min(rescueKits, MAX_RESCUE_KITS) * 10 + blueTilesVisited * 10 - run.LoPs * 15;
   score += Math.max(reliabilityBonus, 0);
 
-
+  //Exit bonus: (SVI) × 10 + (SBV) × 10 + (SSN) × 5 + (SRN) × 5
   if (run.exitBonus) {
-    score += totalVictimCount * 10;
+    const exitBonus = totalVictimCount * 10 + blueTilesVisited * 10 + stairsNavigation * 5 + rampNavigation * 5;
+    score += exitBonus;
   }
 
   score -= Math.min(run.misidentification * 5, score);

--- a/public/javascripts/manual/maze_2026.js
+++ b/public/javascripts/manual/maze_2026.js
@@ -99,6 +99,11 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
             $scope.tiles[response.data.tiles[i].x + ',' +
                 response.data.tiles[i].y + ',' +
                 response.data.tiles[i].z] = response.data.tiles[i];
+            if (response.data.tiles[i].scoredItems.blue > 0) {
+                $scope.tiles[response.data.tiles[i].x + ',' +
+                response.data.tiles[i].y + ',' +
+                response.data.tiles[i].z].scoredItems.blueActive = true;
+            }
         }
 
         let mapId = response.data.map;
@@ -309,7 +314,7 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
         if(item.direction){//Victims
             return $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.victims[item.direction];
         }else if(item.type == 'blue'){
-            return true;
+            return $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blue > 0 || $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blueActive;
         }else{
             return $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems[item.type];
         }
@@ -349,7 +354,14 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
         if(item.direction) {//Victims
             $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.victims[item.direction] = !$scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.victims[item.direction];
         }else if(item.type == 'blue'){
-            // No action for blue here, handled by input field directly in pug
+            $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blueActive = !$scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blueActive;
+            if (!$scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blueActive) {
+                $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blue = 0;
+            } else {
+                if ($scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blue == 0) {
+                    $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blue = 1;
+                }
+            }
         }else{
             $scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems[item.type] = !$scope.tiles[item.x + ',' + item.y + ',' + item.z].scoredItems[item.type];
         }

--- a/public/javascripts/sign/maze_2026.js
+++ b/public/javascripts/sign/maze_2026.js
@@ -209,6 +209,31 @@ app.controller('ddController', ['$scope', '$uibModal', '$log', '$timeout', '$htt
         return count;
     }
 
+    $scope.stairsNavigation = function () {
+        let count = 0;
+        for (const key in $scope.tiles) {
+            if ($scope.tiles[key].scoredItems.steps) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    $scope.rampNavigation = function () {
+        let count = 0;
+        for (const key in $scope.tiles) {
+            if ($scope.tiles[key].scoredItems.ramp) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    $scope.exitBonusPoints = function () {
+        if (!$scope.exitBonus) return 0;
+        return $scope.foundVictims * 10 + $scope.blueTilesVisited() * 10 + $scope.stairsNavigation() * 5 + $scope.rampNavigation() * 5;
+    }
+
     $scope.rescueDeploymentPoints = function () {
         return Math.min($scope.distKits, 8) * 10;
     }

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -558,7 +558,10 @@
             "write": "@:line.sign.write",
             "clear": "@:line.sign.clear",
             "comp": "@:line.sign.comp",
-            "blue": "Successful blue tile visits"
+            "blue": "Successful bluetile visits",
+            "exit": "Exit bonus",
+            "stairs": "Successful stair navigation",
+            "ramp": "Successful ramp navigation"
         }
     },
     "admin": {

--- a/public/lang/ja.json
+++ b/public/lang/ja.json
@@ -556,7 +556,10 @@
             "write": "@:line.sign.write",
             "clear": "@:line.sign.clear",
             "comp": "@:line.sign.comp",
-            "blue": "訪問した青いタイル"
+            "blue": "訪問した青いタイル",
+            "exit": "脱出ボーナス",
+            "stairs": "階段の走破",
+            "ramp": "スロープの走破"
         }
     },
     "admin": {

--- a/views/manual/input/maze_2026.pug
+++ b/views/manual/input/maze_2026.pug
@@ -133,8 +133,11 @@ html(ng-app="ddApp")
                           div(style="width:40px;height:40px;background-color:blue;margin-left:auto;margin-right:auto;border:1px solid #444;")
                         td(style="width:35px;text-align:center;")
                           span(style="font-size:30px") {{item.name}}
+                        td(style="width:40px;")
+                          button.btn(type='button', ng-click="toggleScored(item)", ng-class="{'btn-success': clearStatus(item),'btn-danger':!clearStatus(item)}", style="width:100%;height:100%;")
+                            i.far(ng-class="{'fa-check-square': clearStatus(item), 'fa-times-circle': !clearStatus(item)}")
                         td
-                          input.form-control(type='number', ng-model="tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blue", min='0', style="width:100%;height:100%;font-size:25px;text-align:center;")
+                          input.form-control(type='number', ng-model="tiles[item.x + ',' + item.y + ',' + item.z].scoredItems.blue", min='0', ng-disabled="!clearStatus(item)", style="width:100%;height:100%;font-size:25px;text-align:center;padding:0;")
 
 
         hr

--- a/views/view/common/maze_2026.pug
+++ b/views/view/common/maze_2026.pug
@@ -223,67 +223,108 @@
 hr
 h2 {{'maze.sign.reliability' | translate}}
 .alert.alert-info(style='margin-bottom:30px;text-align:center;', role='alert', ng-if="leagueType=='standard'")
-  .row
+  .row(style='display: flex; align-items: center;')
     .col-md-2
-      p(style='text-align:center;height:40px;') {{'maze.sign.rescue' | translate}}
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.rescue' | translate}}
       i.fas.fa-child.fa-2x(aria-hidden='true')
         | : {{foundVictims}}
-        br
-        br
-        |                     {{foundVictims * 10}} {{'common.point' | translate}}
-    .col-md-1
-      h1(style='line-height:140px;text-align:center;') +
+      br
+      br
+      |                     {{foundVictims * 10}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') +
     .col-md-2
-      p(style='text-align:center;height:40px;') {{'maze.sign.kits' | translate}}
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.kits' | translate}}
       i.fas.fa-medkit.fa-2x(aria-hidden='true')
         | : {{distKits}}
-        br
-        br
-        |                     {{rescueDeploymentPoints()}} {{'common.point' | translate}}
-    .col-md-1
-      h1(style='line-height:140px;text-align:center;') +
+      br
+      br
+      |                     {{rescueDeploymentPoints()}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') +
     .col-md-2
-      p(style='text-align:center;height:40px;') {{'maze.sign.blue' | translate}}
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.blue' | translate}}
       i.fas.fa-trailer.fa-2x(aria-hidden='true')
         | : {{blueTilesVisited()}}
-        br
-        br
-        |                     {{blueTilesVisited() * 10}} {{'common.point' | translate}}
-    .col-md-1
-      h1(style='line-height:140px;text-align:center;') -
+      br
+      br
+      |                     {{blueTilesVisited() * 10}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') -
     .col-md-2
-      p(style='text-align:center;height:40px;') {{'maze.sign.total_lops' | translate}}
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.total_lops' | translate}}
       i.fas.fa-step-forward.fa-2x(aria-hidden='true')
         | : {{LoPs}}
-        br
-        br
-        |                     {{reliabilityLoPs()}} {{'common.point' | translate}}
-    .col-md-1
-      h1(style='line-height:140px;text-align:center;') =
+      br
+      br
+      |                     {{reliabilityLoPs()}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') =
     .col-md-2
-      h1(style='line-height:140px;text-align:center;') {{reliability()}} {{'common.point' | translate}}
+      h1(style='text-align:center; margin:0;') {{reliability()}} {{'common.point' | translate}}
 .alert.alert-info(style='margin-bottom:30px;text-align:center;', role='alert', ng-if="leagueType=='entry'")
-  .row
+  .row(style='display: flex; align-items: center;')
     .col-md-3
-      p(style='text-align:center;height:40px;') {{'maze.sign.rescue' | translate}}
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.rescue' | translate}}
       i.fas.fa-child.fa-2x(aria-hidden='true')
         | : {{foundVictims}}
-        br
-        br
-        |                     {{foundVictims * 10}} {{'common.point' | translate}}
+      br
+      br
+      |                     {{foundVictims * 10}} {{'common.point' | translate}}
     .col-md-1
-      h1(style='line-height:140px;text-align:center;') -
-    .col-md-3
-      p(style='text-align:center;height:40px;') {{'maze.sign.total_lops' | translate}}
+      h1(style='text-align:center; margin:0;') -
+    .col-md-4
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.total_lops' | translate}}
       i.fas.fa-step-forward.fa-2x(aria-hidden='true')
         | : {{LoPs}}
-        br
-        br
-        |                     {{reliabilityLoPs()}} {{'common.point' | translate}}
+      br
+      br
+      |                     {{reliabilityLoPs()}} {{'common.point' | translate}}
     .col-md-1
-      h1(style='line-height:140px;text-align:center;') =
+      h1(style='text-align:center; margin:0;') =
     .col-md-3
-      h1(style='line-height:140px;text-align:center;') {{reliability()}} {{'common.point' | translate}}
+      h1(style='text-align:center; margin:0;') {{reliability()}} {{'common.point' | translate}}
+h2(ng-if="exitBonus") {{'maze.sign.exit' | translate}}
+.alert.alert-success(style='margin-bottom:30px;text-align:center; background-color: #e2d9f3; border-color: #d1c4e9; color: #4527a0;', role='alert', ng-if="exitBonus")
+  .row(style='display: flex; align-items: center;')
+    .col-md-2
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.rescue' | translate}}
+      i.fas.fa-child.fa-2x(aria-hidden='true')
+        | : {{foundVictims}}
+      br
+      br
+      |                     {{foundVictims * 10}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') +
+    .col-md-2
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.blue' | translate}}
+      i.fas.fa-trailer.fa-2x(aria-hidden='true')
+        | : {{blueTilesVisited()}}
+      br
+      br
+      |                     {{blueTilesVisited() * 10}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') +
+    .col-md-2
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.stairs' | translate}}
+      i.fas.fa-align-left.fa-2x(aria-hidden='true')
+        | : {{stairsNavigation()}}
+      br
+      br
+      |                     {{stairsNavigation() * 5}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') +
+    .col-md-2
+      p(style='text-align:center;height:40px; margin-bottom:0;') {{'maze.sign.ramp' | translate}}
+      i.fas.fa-terminal.fa-2x.fa-rotate-315(aria-hidden='true')
+        | : {{rampNavigation()}}
+      br
+      br
+      |                     {{rampNavigation() * 5}} {{'common.point' | translate}}
+    .col-md-half(style='width: 4%;')
+      h1(style='text-align:center; margin:0;') =
+    .col-md-2
+      h1(style='text-align:center; margin:0;') {{exitBonusPoints()}} {{'common.point' | translate}}
 h2 {{'maze.sign.calc' | translate}}
 .alert.alert-warning(style='margin-bottom:80px;text-align:center;', role='alert')
   .row
@@ -293,19 +334,22 @@ h2 {{'maze.sign.calc' | translate}}
         | {{allItemScore()}} {{'common.point' | translate}}
     .col-md-1
       p(style='height:30px;')
-      h1 +
+      h1
+        | +
     .col-md-2
       p(style='height:30px;') {{'maze.sign.reliability' | translate}}
       h1 {{reliability()}} {{'common.point' | translate}}
     .col-md-1
       p(style='height:30px;')
-      h1 +
+      h1
+        | +
     .col-md-2
-      p(style='text-align:center;height:30px;') {{'maze.sign.return' | translate}}
-      h1 {{foundVictims * 10 * exitBonus}} {{'common.point' | translate}}
+      p(style='height:30px;') {{'maze.sign.exit' | translate}}
+      h1 {{exitBonusPoints()}} {{'common.point' | translate}}
     .col-md-1
       p(style='height:30px;')
-      h1 -
+      h1
+        | -
     .col-md-2
       p(style='height:30px;') {{'maze.sign.misidentification' | translate}}
       h1 {{MisIdent*5}} {{'common.point' | translate}}


### PR DESCRIPTION
## Description
This pull request introduces updates to the Maze 2026 templates, logic, and UI. Specifically:
- A toggle button has been added for blue tile scoring, with input disabled when inactive.
- Stairs and ramp navigation tracking has been integrated into the frontend templates and translations.
- Exit bonus breakdown is displayed in the Maze 2026 UI.
- The backend scoring logic now accounts for stairs and ramp navigation, including them in the exit bonus calculation.

Fixes #92

## Type of Change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules