### PR TITLE
Restore isFinished toggle in mapEditor line/maze

### DIFF
--- a/public/stylesheets/admin/mapEditor/line_modern.css
+++ b/public/stylesheets/admin/mapEditor/line_modern.css
@@ -464,6 +464,7 @@ tile,
     transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
     user-select: none;
+    font-weight: 700;
 }
 
 .settings-checkbox-container:hover {

--- a/public/stylesheets/admin/mapEditor/maze_modern.css
+++ b/public/stylesheets/admin/mapEditor/maze_modern.css
@@ -464,3 +464,59 @@ tr:hover .grid-manage-row .btn-grid-manage {
     box-shadow: none;
     background: transparent;
 }
+
+.settings-checkbox-container {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  background: #f8fafc;
+  border: 2px solid #e2e8f0;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  user-select: none;
+  font-weight: 700;
+}
+
+.settings-checkbox-container:hover {
+  border-color: #cbd5e1;
+  background: #f1f5f9;
+}
+
+.settings-checkbox-container input[type="checkbox"] {
+  display: none;
+}
+
+.settings-checkbox-container.active {
+  background: #eff6ff;
+  border-color: #3b82f6;
+  color: #1e40af;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.1);
+}
+
+.settings-checkbox-container.active i {
+  color: #3b82f6 !important;
+}
+
+.settings-checkbox-container.active::after {
+  content: '\f058'; /* fa-check-circle */
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background: white;
+  color: #3b82f6;
+  font-size: 1.1rem;
+  line-height: 1;
+  border-radius: 50%;
+  z-index: 10;
+}
+
+.settings-checkbox-container.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  background: #f1f5f9;
+  pointer-events: none;
+}

--- a/views/admin/competition.pug
+++ b/views/admin/competition.pug
@@ -80,7 +80,7 @@ block main_content
             i.fas(ng-class="{'fa-route': league.type=='line', 'fa-border-all': league.type=='maze', 'fa-desktop': league.type=='simulation'}")
             | {{league.name}}
           .d-flex.justify-content-between
-            button.btn-premium.btn-premium-secondary.flex-grow-1(ng-disabled="league.type == 'simulation'" ng-click="go('/admin/' + competitionId + '/' + league.league + '/maps'); $event.stopPropagation();" style="padding: 0.8rem 0.5rem; font-size: 0.85rem; margin-right: 1.25rem;")
+            button.btn-premium.btn-premium-secondary.flex-grow-1(ng-if="league.type != 'simulation'" ng-click="go('/admin/' + competitionId + '/' + league.league + '/maps'); $event.stopPropagation();" style="padding: 0.8rem 0.5rem; font-size: 0.85rem; margin-right: 1.25rem;")
               i.fas.fa-ruler-combined
               | {{'admin.competition.maps_short' | translate}}
             button.btn-premium.btn-premium-primary.flex-grow-1(style="padding: 0.8rem 0.5rem; font-size: 0.85rem;" ng-style="{'background': 'var(--league-color)', 'borderColor': 'var(--league-color)'}")

--- a/views/admin/mapEditor/line_2026.pug
+++ b/views/admin/mapEditor/line_2026.pug
@@ -218,7 +218,7 @@ block main_content
         //- Tile Palette Section
         .col-auto.h-100(style="width: 360px;")
           .modern-card(style="height: 100%; display: flex; flex-direction: column; margin-bottom: 0;")
-            .modern-card-header.py-2.px-3
+            .modern-card-header.py-3.px-3
               .d-flex.justify-content-between.align-items-center.w-100
                 span.small.font-weight-bold.text-uppercase.letter-spacing-1
                   i.fas.fa-palette.mr-2
@@ -271,6 +271,10 @@ block main_content
         
         #outputCollapse.collapse.show
           .modern-card-body.bg-light
+            label.settings-checkbox-container(ng-class="{'active': finished}")
+              input#isFinished(type='checkbox',ng-model='finished')
+              i.fas.fa-flag-checkered.mr-2
+              Span {{"admin.lineMapEditor.finished" | translate}}
             .print-section
               label.section-title {{ 'admin.mazeMapAdmin.print.outputContent' | translate }}
               .option-tiles

--- a/views/admin/mapEditor/maze_2026.pug
+++ b/views/admin/mapEditor/maze_2026.pug
@@ -276,6 +276,10 @@ block main_content
         
         #outputCollapse.collapse
           .modern-card-body.bg-light
+            label.settings-checkbox-container(ng-class="{'active': finished}")
+              input#isFinished(type='checkbox',ng-model='finished')
+              i.fas.fa-flag-checkered.mr-2
+              Span {{"admin.lineMapEditor.finished" | translate}}
             .print-section
               label.section-title {{ 'admin.mazeMapAdmin.print.outputContent' | translate }}
               .option-tiles


### PR DESCRIPTION
## Description

Restores the missing isFinished option in the map output generation tools after it was lost during the 2026 editor UI modernization.  
The “Finished” flag is required to mark a map as competition-ready. Without this option, maps could not be marked as finished and therefore could not be used in schedule generation and other workflows that depend on completed maps.  
The advanced tools section was updated, and the missing toggle was reintroduced using the modern settings component.  

Fixes # (no issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Tested in the Rescue Line Map Editor:  
1. Opened the Advanced Tools section.
2. Verified that the “Finished” option is displayed.
3. Verified that the checkbox state can be toggled and saved.
4. Verified that the updated UI styling matches the rest of the 2026 editor.
5. Verified that finished maps can be used for schedule generation.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings